### PR TITLE
Modified readme and variable names.

### DIFF
--- a/monte_carlo_simulation/algorithms/README.md
+++ b/monte_carlo_simulation/algorithms/README.md
@@ -1,6 +1,6 @@
-# Benchmarking Amlitude Estimation Algorithms
+# Benchmarking Amplitude Estimation Algorithms
 
-Amplitude Estimation (AE) has been first introduced by Brassard et al. (refered to here as "[Canonical AE](https://arxiv.org/abs/quant-ph/0005055)").
+Amplitude Estimation (AE) has been first introduced by Brassard et al. (referred to here as "[Canonical AE](https://arxiv.org/abs/quant-ph/0005055)").
 AE is an algorithm that may allow to speed-up many applications, such as derivative pricing or risk analysis.
 In recent years, many variants of AE without quantum phase estimation have been proposed.
 In the following, we give an overview of these variants as well as some of their properties and links to relevant papers.
@@ -8,39 +8,39 @@ In the following, we give an overview of these variants as well as some of their
 
 | Algorithm | Year | Benchmarked | Comments |
 |-----------|------|-------------|----------|
-| [Maximum Likelihood AE (MLAE)](https://link.springer.com/article/10.1007/s11128-019-2565-2) | 2020 | TBD |                                       |
-| [Iterative AE (IAE)](https://www.nature.com/articles/s41534-021-00379-1)                    | 2021 | X   |                                       |
-| [Low Depth AE](https://quantum-journal.org/papers/q-2022-06-27-745/)                        | 2022 | TBD |                                       |
-| [Modified Iterative AE](https://arxiv.org/abs/2208.14612)                                   | 2022 | TBD | Asymptotically optimal variant of IAE |
-| [Random Depth AE](https://arxiv.org/abs/2301.00528)                                         | 2023 | TBD |                                       |
+| [Maximum Likelihood AE (MLAE)](https://link.springer.com/article/10.1007/s11128-019-2565-2) | 2020 | TBD |                                        |
+| [Iterative AE (IQAE)](https://www.nature.com/articles/s41534-021-00379-1)                   | 2021 | Yes |                                        |
+| [Low Depth AE](https://quantum-journal.org/papers/q-2022-06-27-745/)                        | 2022 | TBD |                                        |
+| [ChebPE](https://arxiv.org/abs/2207.08628)                                                  | 2022 | Yes | Variant of ChebAE for probabilities    |
+| [Modified Iterative AE](https://arxiv.org/abs/2208.14612)                                   | 2022 | TBD | Asymptotically optimal variant of IQAE |
+| [Random Depth AE](https://arxiv.org/abs/2301.00528)                                         | 2023 | TBD |                                        |
 
 In the directory [results](/monte_carlo_simulation/algorithms/results/) we provide benchmarking results for these algorithms for different scenarios.
-For every algorithm, benchmarks are done according to the following setting:
 
-For every
-- exact value $a^*^2 = 0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99$,
-- estimated/target accuracy (depending on the algorithm) $\epsilon = 10^{-k}, k = 1, \ldots, 6$, and
+The objective of amplitude estimation is as follows. For an unknown amplitude $a_\text{target} \in [0,1]$, there is a quantum subroutine that for any $k \in 0,1,2,...$ samples from Bernoulli random variable with parameter $\sin^2( (2k+1) \theta_\text{target}  )$ where $\theta_\text{target} = \arcsin(a_\text{target})$. Running this subroutine requires $k$ oracle calls. The objective is to estimate the probability $p_\text{target} := a^2_\text{target}$ using as few oracle calls as possible.
+
+For every algorithm, 100 data points are to be collected for all combinations of the following parameters:
+- target probability $p_\text{target} = 0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99$,
+- the desired accuracy $\epsilon = 10^{-k},$ where $ k = 1, \ldots, 6$, and
 - confidence level $1-\alpha = 0.95$,
 
-the considered algorithms are repeated 100 times and the number of calls to the oracle $Q$ is counted for each repetition.
-Further, the actually achieve accuracy as well as the half-width of the a posteriori confidence intervals (for confidence level $1-\alpha$) are reported.
-The corresponding algorithmic parameters to achieve the results should be given in a JSON dictionary in the column `config`.
+The desired accuracy should inform the half-width of the a posteriori confidence intervals (for confidence level $1-\alpha$), but algorithms are not penalized for overshooting the desired accuracy. Further, the actually achieved accuracy is reported. The corresponding algorithmic parameters to achieve the results should be given in a JSON dictionary in the column `config`.
 The raw results are reported in the format (cf. [results/results_template.csv](results/results_template.csv)):
 
 
-| algorithm | config | a_target | alpha | a_estimate | exact_error | ci_width    | num_oracle_calls |
+| algorithm | config | p_target | alpha | p_estimate | exact_error | ci_width    | num_oracle_calls |
 |-----------|--------|----------|-------|------------|-------------|-------------|------------------|
 | IAE       | {...}  | 0.25     | 0.05  | 0.28       | 0.03        | 0.12        | 100              |
 
-The colums are defined as follows:
+The columns are defined as follows:
 - `algorithm`: The name or abbreviation of the considered algorithm.
 - `config`: A dictionary summarizing the algorithm settings for reproducability.
-- `a_target`: The true `a^*` value of the considered problem.
+- `p_target`: The true $p_\text{target}$ value of the considered problem.
 - `alpha`: $(1-\alpha)$ determines the confidence level of the a posterori confidence intervals.
-- `a_estimate`: The estimated `a` value returned by the algorithm.
-- `exact_error`: The exact error between `a_target` and `a_estimate`.
-- `ci_width`: The half-width of the a posteriori confidence interval, i.e., the estimate error.
-- `num_oracle_calls`: The used number of oracle calls to achieve the reported results.
+- `p_estimate`: The estimate of $p_\text{target}$ returned by the algorithm.
+- `exact_error`: The distance between `p_target` and `p_estimate`. In a successful run this should be less than `ci_width`.
+- `ci_width`: The half-width of the a posteriori confidence interval, which should be less than the desired accuracy $\epsilon$.
+- `num_oracle_calls`: The number of oracle calls used to achieve the reported results.
 
 An overview of all available results is illustrated in the [results summary](results_summary.ipynb).
 

--- a/monte_carlo_simulation/algorithms/results/2023-02-03_iae_results/2023-02-03_iae_results.csv
+++ b/monte_carlo_simulation/algorithms/results/2023-02-03_iae_results/2023-02-03_iae_results.csv
@@ -1,4 +1,4 @@
-algorithm,config,a_target,alpha,a_estimate,exact_error,ci_width,num_oracle_calls
+algorithm,config,p_target,alpha,p_estimate,exact_error,ci_width,num_oracle_calls
 IAE,"{'epsilon_target': 0.1, 'alpha': 0.05,  'shots': 100}",0.01,0.05,0.011685781081200509,0.001685781081200509,0.005204246204401542,200
 IAE,"{'epsilon_target': 0.1, 'alpha': 0.05,  'shots': 100}",0.01,0.05,0.008910666410254092,0.001089333589745908,0.004525146335811875,200
 IAE,"{'epsilon_target': 0.1, 'alpha': 0.05,  'shots': 100}",0.01,0.05,0.008784243864504241,0.0012157561354957588,0.0032452640914093812,300

--- a/monte_carlo_simulation/algorithms/results/results_template.csv
+++ b/monte_carlo_simulation/algorithms/results/results_template.csv
@@ -1,2 +1,2 @@
-algorithm,config,a_target,alpha,a_estimate,exact_error,ci_width,num_oracle_calls
+algorithm,config,p_target,alpha,p_estimate,exact_error,ci_width,num_oracle_calls
 IAE,"{'epsilon_target': 1e-1, 'alpha': 0.05, 'shots': 100}",0.25,0.05,0.275,0.025,0.05,200


### PR DESCRIPTION
This pull request makes some changes to the README for amplitude estimation benchmarking.
It fixes several typos and clarifies some details, but the major change is to rename the parameter that is being estimated from $a$ to $p := a^2$. This change is also propagated to the template file and the existing IQAE data.

There are still a couple of contentious points in the methodology:
- 100 shots per data point is a little low. This isn't really enough to check if the algorithms are performing reliably.
- Algorithms are not penalized for overshooting the desired accuracy. If you tell me to give you an estimate to accuracy 10^(-3), but then I spend a much higher query complexity then necessary and give you an estimate to accuracy 10^(-5), then from the point of view of this benchmark this is totally OK. This could be addressed by making the target accuracy a more 'official' parameter. MLAE in particular is quite bad about overshooting the desired accuracy - but rather than gloss over this I think this should be penalized.